### PR TITLE
Oliver/ax time travel

### DIFF
--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -448,7 +448,7 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
           addAxSnap(response.nodes);
           await detachDebugger(tabId);
         } catch (error) {
-          console.error('Debugger command failed:', error);
+          console.error('axRecord debugger command failed:', error);
         }
       }
       const sourceTab = tabId;

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -398,7 +398,10 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
       break;
     }
     case 'recordSnap': {
-      console.log('background.js: recordSnap: tabsObj[tabId]:', tabsObj[tabId]);
+      console.log(
+        'background.js: top of recordSnap: tabsObj[tabId]:',
+        JSON.parse(JSON.stringify(tabsObj[tabId])),
+      );
       function addAxSnap(snap) {
         const pruned = pruneAxTree(snap);
         tabsObj[tabId].axSnapshots.push(pruned);

--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -93,7 +93,7 @@ function createTabObj(title) {
 // 1. param 'obj' : arg request.payload, which is an object containing a tree from snapShot.ts and a route property
 // 2. param tabObj: arg tabsObj[tabId], which is an object that holds info about a specific tab. Should change the name of tabObj to tabCollection or something
 class HistoryNode {
-  constructor(obj, tabObj, axSnap) {
+  constructor(obj, tabObj) {
     // continues the order of number of total state changes
     this.index = tabObj.index;
     tabObj.index += 1;


### PR DESCRIPTION
Removed axSnap parameter from historynode constructor. AxSnapshots are now being added to hierarchy of tabsObj[tabId]. Earlier, removed recordaxsnap window.postmessage(). tabsObj is console.logged now whenever snapshot is recorded.